### PR TITLE
Fix replacing workspace name with some environment variables.

### DIFF
--- a/deployfish/config.py
+++ b/deployfish/config.py
@@ -143,7 +143,7 @@ class Config(object):
                 'cluster-name': service['cluster']
             }
             if 'workspace' in self.__raw['terraform']:
-                self.__raw['terraform']['workspace'].format(**replacers)
+                self.__raw['terraform']['workspace'] = self.__raw['terraform']['workspace'].format(**replacers)
             else:
                 self.__raw['terraform']['statefile'] = self.__raw['terraform']['statefile'].format(**replacers)
 


### PR DESCRIPTION
string.replace() was missing assignment.